### PR TITLE
Fix small issues after updating to bootstrap 5

### DIFF
--- a/flowapp/static/js/enable_tooltips.js
+++ b/flowapp/static/js/enable_tooltips.js
@@ -1,0 +1,4 @@
+var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+  return new bootstrap.Tooltip(tooltipTriggerEl)
+})

--- a/flowapp/templates/forms/macros.j2
+++ b/flowapp/templates/forms/macros.j2
@@ -15,13 +15,21 @@
         {% endif %}
         {% if tooltip %}
             <div class="input-group">
-              {{ field(class_='form-control', **kwargs) }}
+              {% if field.type == 'SelectField' %}
+                    {{ field(class_='form-select', **kwargs) }}
+                {% else %}
+                    {{ field(class_='form-control', **kwargs) }}
+                {% endif %}
                <span class="input-group-text" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ tooltip }}">
                     <i class="bi bi-question-square-fill"></i>
               </span>
             </div>  
         {% else %}
-            {{ field(class_='form-control', **kwargs) }}
+            {% if field.type == 'SelectField' %}
+                    {{ field(class_='form-select', **kwargs) }}
+                {% else %}
+                    {{ field(class_='form-control', **kwargs) }}
+                {% endif %}
         {% endif %}
         {% if field.errors %}
             {% for e in field.errors %}

--- a/flowapp/templates/forms/macros.j2
+++ b/flowapp/templates/forms/macros.j2
@@ -16,7 +16,7 @@
         {% if tooltip %}
             <div class="input-group">
               {{ field(class_='form-control', **kwargs) }}
-               <span class="input-group-text data-toggle="tooltip"  title="{{ tooltip }}">
+               <span class="input-group-text" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ tooltip }}">
                     <i class="bi bi-question-square-fill"></i>
               </span>
             </div>  

--- a/flowapp/templates/layouts/default.j2
+++ b/flowapp/templates/layouts/default.j2
@@ -97,6 +97,6 @@
     </nav>
 
     <script type="text/javascript" src="/static/js/ip_context.js"></script>  
-
+    <script type="text/javascript" src="/static/js/enable_tooltips.js"></script>
   </body>
 </html>

--- a/flowapp/templates/layouts/default.j2
+++ b/flowapp/templates/layouts/default.j2
@@ -62,9 +62,9 @@
               </li>
               {% endif %}
             </ul>
-            <p class="navbar-text">
+            <span class="navbar-text">
               {{ session['user_name']}} &lt;{{ session['user_email'] }}&gt;, 
-              role: {{ session['user_roles']|join(", ") }}, org: {{ session['user_orgs'] }}</p>
+              role: {{ session['user_roles']|join(", ") }}, org: {{ session['user_orgs'] }}</span>
           </div>    
         
         </div>


### PR DESCRIPTION
Fixed tooltips (bootstrap now uses data-bs-* instead of data-*), dropdown arrows in forms on select elements (requires the form-select css class instead of form-control) and fix broken text in navbar (p element caused the text to not be horizontally centered - changing it to span fixed it)