### PR TITLE
Fix small issues after updating to bootstrap 5

### DIFF
--- a/flowapp/templates/forms/ipv4_rule.j2
+++ b/flowapp/templates/forms/ipv4_rule.j2
@@ -36,7 +36,7 @@
           {{ render_field(form.flags, size=9) }}
     </div>
 
-  </div>  
+  </div>
 
   <div class="row">
     <div class="col-sm-4">
@@ -54,16 +54,16 @@
   <div class="row">
     <div class="col-sm-6">
       {{ render_field(form.action) }}
-    </div>    
+    </div>
     <div class="col-sm-6">
       <div class="form-group">
         <label for="inputExpiration" class="control-label">Expiration date</label>
         <div class='input-group date' id='dateTimeExpires'>
                       <!--
                       <input type='text' name="expires" class="form-control" />
-                     
+
                       -->
-                      {{ form.expires(class_='form-control') }} 
+                      {{ form.expires(class_='form-control') }}
                       <span class="input-group-addon">
                           <span class="glyphicon glyphicon-calendar"></span>
                       </span>
@@ -74,7 +74,7 @@
                 <p class="help-block">{{ e }}</p>
             {% endfor %}
         {% endif %}
-      </div>            
+      </div>
     </div>
   </div>
 
@@ -89,4 +89,5 @@
       <button type="submit" class="btn btn-primary">Save</button>
     </div>
   </div>
+  </form>
 {% endblock %}

--- a/flowapp/templates/forms/ipv6_rule.j2
+++ b/flowapp/templates/forms/ipv6_rule.j2
@@ -82,6 +82,7 @@
       <button type="submit" class="btn btn-primary">Save</button>
     </div>
   </div>
+  </form>
 
 <script type="text/javascript">
             $(function () {

--- a/flowapp/templates/forms/macros.j2
+++ b/flowapp/templates/forms/macros.j2
@@ -13,23 +13,20 @@
         {% if (field.type != 'HiddenField' and field.type !='CSRFTokenField') and label_visible %}
             <label for="{{ field.id }}" class="control-label">{{ field.label }}</label>
         {% endif %}
+        {% if field.type == 'SelectField' %}
+            {% set input_class = 'form-select' %}
+        {% else %}
+            {% set input_class = 'form-control' %}
+        {% endif %}
         {% if tooltip %}
             <div class="input-group">
-              {% if field.type == 'SelectField' %}
-                    {{ field(class_='form-select', **kwargs) }}
-                {% else %}
-                    {{ field(class_='form-control', **kwargs) }}
-                {% endif %}
-               <span class="input-group-text" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ tooltip }}">
+                {{ field(class_=input_class, **kwargs) }}
+                <span class="input-group-text" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ tooltip }}">
                     <i class="bi bi-question-square-fill"></i>
               </span>
-            </div>  
+            </div>
         {% else %}
-            {% if field.type == 'SelectField' %}
-                    {{ field(class_='form-select', **kwargs) }}
-                {% else %}
-                    {{ field(class_='form-control', **kwargs) }}
-                {% endif %}
+            {{ field(class_=input_class, **kwargs) }}
         {% endif %}
         {% if field.errors %}
             {% for e in field.errors %}

--- a/flowapp/templates/forms/macros.j2
+++ b/flowapp/templates/forms/macros.j2
@@ -51,9 +51,10 @@
         {{ macros.render_checkbox_field(form.remember_me) }}
  #}
 {% macro render_checkbox_field(field) -%}
-    <div class="checkbox">
-        <label>
-            {{ field(type='checkbox', **kwargs) }} {{ field.label }}
+    <div class="form-check">
+        {{ field(type='checkbox', class_='form-check-input', **kwargs) }}
+        <label class="form-check-label" for="{{ field.id }}">
+             {{ field.label }}
         </label>
     </div>
 {%- endmacro %}
@@ -69,9 +70,10 @@
  #}
 {% macro render_radio_field(field) -%}
     {% for value, label, _ in field.iter_choices() %}
-        <div class="radio">
-            <label>
-                <input type="radio" name="{{ field.id }}" id="{{ field.id }}" value="{{ value }}">{{ label }}
+        <div class="form-check">
+            <input type="radio" class="form-check-input" name="{{ field.id }}" id="{{ field.id }}" value="{{ value }}">
+            <label class="form-check-label" for="{{ field.id }}">
+                {{ label }}
             </label>
         </div>
     {% endfor %}

--- a/flowapp/templates/forms/rtbh_rule.j2
+++ b/flowapp/templates/forms/rtbh_rule.j2
@@ -65,6 +65,7 @@
       <button type="submit" class="btn btn-primary">Save</button>
     </div>
   </div>
+  </form>
 
 <script type="text/javascript">
             $(function () {

--- a/flowapp/templates/layouts/default.j2
+++ b/flowapp/templates/layouts/default.j2
@@ -75,9 +75,10 @@
       {% with messages = get_flashed_messages(with_categories=true)  %}
         {% if messages %}
           {% for category, message in messages %}
-            <div class="alert {{category}}" role="alert">
-              <a class="close" data-dismiss="alert">&times;</a>
+            <div class="alert alert-dismissible fade show {{category}}" role="alert">
               {{ message }}
+              <button type="button" class="btn-close" data-bs-dismiss="alert"
+                            aria-label="Close"></button>
             </div>
           {% endfor %}
         {% endif %}

--- a/flowapp/templates/layouts/default.j2
+++ b/flowapp/templates/layouts/default.j2
@@ -30,7 +30,7 @@
       <nav class="navbar fixed-top navbar-expand-lg navbar-dark bg-dark">
         <div class="container">
           <a class="navbar-brand" href="/">{{ config['APP_NAME'] }} / ExaFS_{{ session['app_version'] }}</a>
-          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
           </button>
           <div class="collapse navbar-collapse" id="navbar">

--- a/flowapp/templates/pages/submenu_dashboard.j2
+++ b/flowapp/templates/pages/submenu_dashboard.j2
@@ -35,10 +35,10 @@
             </ul>
         </div>
         <div class="col-6">
-            <ul class="nav nav-pills pull-right">
+            <ul class="nav nav-pills justify-content-end">
                 <li class="nav-item"> 
-                    <form id="dashboard-search" class="navbar-form pull-right" role="search" action="{{ url_for('dashboard.index', rtype=rtype, rstate=rstate) }}">
-                     <div class="input-group mb3">
+                    <form id="dashboard-search" class="navbar-form mx-3" role="search" action="{{ url_for('dashboard.index', rtype=rtype, rstate=rstate) }}">
+                     <div class="input-group">
                         <input 
                             class="form-control"
                             type="search" 


### PR DESCRIPTION
- Checkboxes and radio inputs have different styling now
- Button to open the responsive menu had a wrong target ID
- the `pull-right` class was replaced by `justify-content-end`
- Fixed missing closing `</form>` tags in rule forms