### PR TITLE
fix version import in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,15 @@ Setuptools configuration
 """
 
 import setuptools
-from flowapp.__about__ import __version__
+
+# Import the __version__ variable without having to import the flowapp package.
+# This prevents missing dependency error in new virtual environments.
+with open("flowapp/__about__.py") as f:
+    exec(f.read())
 
 setuptools.setup(
     name="exafs",
-    version=__version__,
+    version=__version__, # noqa: F821
     author="CESNET / Jiri Vrany, Petr Adamec, Josef Verich, Jakub Man",
     description="Tool for creation, validation, and execution of ExaBGP messages.",
     url="https://github.com/CESNET/exafs",


### PR DESCRIPTION
Importing the variable using a regular package import can lead to errors, if installed from a fresh virtual environment, due to __init__.py being executed and failing on missing packages.

This PR fixes the issue by executing the __about__.py file directly instead of importing it using the flowapp module.