### PR TITLE
Fix /0 IP mask being set to /32 or /128

### DIFF
--- a/flowapp/messages.py
+++ b/flowapp/messages.py
@@ -244,7 +244,7 @@ def sanitize_mask(rule_mask, default_mask=IPV4_DEFMASK):
     :param rule: flowspec rule
     :return: int mask
     """
-    if not rule_mask:
+    if rule_mask is None:
         return default_mask
 
     if 0 <= rule_mask <= default_mask:

--- a/flowapp/templates/macros.j2
+++ b/flowapp/templates/macros.j2
@@ -10,13 +10,13 @@
 
         <tr {% if rule.expires < today %} class="warning" {% endif %}>
             <td>
-                <span class="task">{{ rule.source }}</span>{% if rule.source_mask %}{{ '/' if rule.source_mask >= 0 else '' }}{{ rule.source_mask if rule.source_mask >= 0 else '' }}{% endif %}
+                <span class="task">{{ rule.source }}</span>{% if rule.source_mask != none %}{{ '/' if rule.source_mask >= 0 else '' }}{{ rule.source_mask if rule.source_mask >= 0 else '' }}{% endif %}
             </td>
             <td>
                 {{ rule.source_port }}
             </td>
             <td>
-                <span class="task">{{ rule.dest }}</span>{% if rule.dest_mask %}{{ '/' if rule.dest_mask >= 0 else '' }}{{ rule.dest_mask if rule.dest_mask >= 0 else '' }}{% endif %}
+                <span class="task">{{ rule.dest }}</span>{% if rule.dest_mask != none %}{{ '/' if rule.dest_mask >= 0 else '' }}{{ rule.dest_mask if rule.dest_mask >= 0 else '' }}{% endif %}
             </td>
             <td>
                 {{ rule.dest_port }}


### PR DESCRIPTION
Explicitly specifying /0 IP mask was being interpreted as it not being set at all. This PR fixes the issue.