### PR TITLE
Support for authentication using external proxy

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -9,6 +9,12 @@ class Config():
     TESTING = False
     # SSO auth enabled
     SSO_AUTH = False
+    # Authentication is done outside the app, use HTTP header to get the user uuid.
+    # If SSO_AUTH is set to True, this option is ignored and SSO auth is used.
+    HEADER_AUTH = True
+    # Name of HTTP header containing the UUID of authenticated user.
+    # Only used when HEADER_AUTH is set to True
+    AUTH_HEADER_NAME = 'X-Authenticated-User'
     # SSO LOGOUT
     LOGOUT_URL = "https://flowspec.example.com/Shibboleth.sso/Logout"
     # SQL Alchemy config

--- a/flowapp/templates/errors/401.j2
+++ b/flowapp/templates/errors/401.j2
@@ -1,0 +1,7 @@
+{% extends 'layouts/default.j2' %}
+{% block content %}
+  <h1>Could not log you in.</h1>
+  <p class="form-text">401: Unauthorized</p>
+  <p>Please log out and try logging in again.</p>
+  <p><a href="{{url_for('logout')}}">Log out</a></p>
+{% endblock %}


### PR DESCRIPTION
Simplified version of #32 that uses external proxy instead of implementing authentication directly in ExaFS.

Makes use of proxy such as Apache that handles the authentication and fills the specified HTTP header.

Example of Apache configuration for database authentication:

```
# mod_dbd configuration
DBDriver pgsql
DBDParams "dbname=exafs_users host=localhost user=exafs password=verysecurepassword"

DBDMin  4
DBDKeep 8
DBDMax  20
DBDExptime 300

# ExaFS authentication
<VirtualHost *:80>
    ServerName example.com
    DocumentRoot /var/www/html

    <Location />
    AuthType Basic
    AuthName "Database Authentication"
    AuthBasicProvider dbd
    AuthDBDUserPWQuery "SELECT pass_hash AS password FROM \"users\" WHERE email = %s"
    Require valid-user
    RequestHeader set X-Authenticated-User expr=%{REMOTE_USER}
    ProxyPass http://127.0.0.1:8080/
    </Location>
</VirtualHost>
```